### PR TITLE
Fix upload button style

### DIFF
--- a/dist/upload/index.wxml
+++ b/dist/upload/index.wxml
@@ -1,15 +1,18 @@
 <view class="wux-class wux-upload {{ listType ? 'wux-upload--' + listType : '' }} {{ disabled ? 'wux-upload--disabled' : '' }}">
-    <view class="wux-upload__files" wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
-        <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
-            <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}" data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
-                <image class="wux-upload__thumb" src="{{ file.url }}" />
-                <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
-            </view>
+    <view class="wux-upload__files">
+        <block wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
+            <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
+                <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}"
+                      data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
+                    <image class="wux-upload__thumb" src="{{ file.url }}"/>
+                    <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
+                </view>
+            </block>
         </block>
-    </view>
-    <view class="wux-upload__select" bindtap="onSelect">
-        <view class="wux-upload__button">
-            <slot></slot>
+        <view class="wux-upload__select" bindtap="onSelect">
+            <view class="wux-upload__button">
+                <slot></slot>
+            </view>
         </view>
     </view>
 </view>

--- a/example/dist/upload/index.wxml
+++ b/example/dist/upload/index.wxml
@@ -1,15 +1,18 @@
 <view class="wux-class wux-upload {{ listType ? 'wux-upload--' + listType : '' }} {{ disabled ? 'wux-upload--disabled' : '' }}">
-    <view class="wux-upload__files" wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
-        <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
-            <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}" data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
-                <image class="wux-upload__thumb" src="{{ file.url }}" />
-                <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
-            </view>
+    <view class="wux-upload__files">
+        <block wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
+            <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
+                <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}"
+                      data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
+                    <image class="wux-upload__thumb" src="{{ file.url }}"/>
+                    <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
+                </view>
+            </block>
         </block>
-    </view>
-    <view class="wux-upload__select" bindtap="onSelect">
-        <view class="wux-upload__button">
-            <slot></slot>
+        <view class="wux-upload__select" bindtap="onSelect">
+            <view class="wux-upload__button">
+                <slot></slot>
+            </view>
         </view>
     </view>
 </view>

--- a/src/upload/index.wxml
+++ b/src/upload/index.wxml
@@ -1,15 +1,18 @@
 <view class="wux-class wux-upload {{ listType ? 'wux-upload--' + listType : '' }} {{ disabled ? 'wux-upload--disabled' : '' }}">
-    <view class="wux-upload__files" wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
-        <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
-            <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}" data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
-                <image class="wux-upload__thumb" src="{{ file.url }}" />
-                <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
-            </view>
+    <view class="wux-upload__files">
+        <block wx:if="{{ listType === 'picture-card' && showUploadList && fileList }}">
+            <block wx:for="{{ fileList }}" wx:for-item="file" wx:key="uid">
+                <view class="wux-upload__file {{ file.status ? 'wux-upload__file--' + file.status : '' }}"
+                      data-file="{{ file }}" data-index="{{ index }}" bindtap="onPreview">
+                    <image class="wux-upload__thumb" src="{{ file.url }}"/>
+                    <view class="wux-upload__remove" data-file="{{ file }}" data-index="{{ index }}" catchtap="onRemove" wx:if="{{ showRemoveIcon }}"></view>
+                </view>
+            </block>
         </block>
-    </view>
-    <view class="wux-upload__select" bindtap="onSelect">
-        <view class="wux-upload__button">
-            <slot></slot>
+        <view class="wux-upload__select" bindtap="onSelect">
+            <view class="wux-upload__button">
+                <slot></slot>
+            </view>
         </view>
     </view>
 </view>


### PR DESCRIPTION
当每行图片超过两个，从第二行开始，即使当前行的图片
没有排满，上传按钮也会被挤到下一行，本次提交，将
上传按钮改为追加到最后一张图后面

修复前：
<img width="334" alt="default" src="https://user-images.githubusercontent.com/5105535/45019248-70c25b00-b05e-11e8-83c5-b8e9b7ac79cb.png">

修复后：
<img width="320" alt="default" src="https://user-images.githubusercontent.com/5105535/45019280-85065800-b05e-11e8-9b7c-e9de67bc8032.png">
