### PR TITLE
dialog.prompt增加cursorSpacing属性,防止输入框被键盘遮挡

### DIFF
--- a/src/dialog/index.js
+++ b/src/dialog/index.js
@@ -168,6 +168,7 @@ Component({
                 response: opts.defaultText ? opts.defaultText : '',
                 placeholder: opts.placeholder ? opts.placeholder : '',
                 maxlength: opts.maxlength ? parseInt(opts.maxlength) : '',
+                cursorSpacing: opts.cursorSpacing ? opts.cursorSpacing : 0
             }
 
             return this.open(Object.assign({

--- a/src/dialog/index.js
+++ b/src/dialog/index.js
@@ -154,6 +154,7 @@ Component({
          * @param {String} opts.defaultText 默认值
          * @param {String} opts.placeholder 输入框为空时占位符
          * @param {Number} opts.maxlength 最大输入长度，设置为 -1 的时候不限制最大长度
+         * @param {Number} opts.cursorSpacing 指定input光标与键盘的距离,单位px，默认为0
          * @param {String} opts.confirmText 确定按钮的文字，默认为"确定"
          * @param {String} opts.confirmType 确定按钮的类型
          * @param {Function} opts.onConfirm 确定按钮的点击事件

--- a/src/dialog/index.wxml
+++ b/src/dialog/index.wxml
@@ -4,7 +4,7 @@
         <text>{{ content }}</text>
         <view class="wux-popup__input-container" wx:if="{{ prompt }}">
             <label>
-                <input type="{{ prompt.fieldtype }}" class="wux-popup__input" value="{{ prompt.response }}" password="{{ prompt.password }}" placeholder="{{ prompt.placeholder }}" maxlength="{{ maxlength }}" bindinput="bindinput" />
+                <input type="{{ prompt.fieldtype }}" class="wux-popup__input" value="{{ prompt.response }}" password="{{ prompt.password }}" placeholder="{{ prompt.placeholder }}" maxlength="{{ maxlength }}" cursor-spacing="{{ prompt.cursorSpacing }}" bindinput="bindinput" />
             </label>
         </view>
     </view>


### PR DESCRIPTION
用法:
 ```
$wuxDialog().prompt({
      resetOnClose: true,
      maskClosable: false,
      cursorSpacing: 100  // 类型:Number,指定input光标与键盘的距离,单位px
})
```