### PR TITLE
优化：阻止popover的点击事件冒泡

### DIFF
--- a/src/popover/index.wxml
+++ b/src/popover/index.wxml
@@ -12,6 +12,6 @@
         </view>
     </wux-animation-group>
 </view>
-<view class="{{ classes.element }}" bindtap="onClick">
+<view class="{{ classes.element }}" catchtap="onClick">
     <slot></slot>
 </view>


### PR DESCRIPTION
这样做可以实现在父组件监听点击事件，来隐藏popover（在不想使用mask的情况下）。就不用依然点这个popover才能隐藏掉它。