### PR TITLE
fixed: Update gulpfile.babel.js,  px tp rpx 的操作，如果数值位于 base64 数据内部，会存在问题。

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -39,14 +39,15 @@ const paths = {
  */
 const px2Rpx = () => {
 
-    // 正则匹配
-    const pxReplace = (value = '') => {
-        const pxRegExp = /(\d*\.?\d+)px/ig
-        const pxReplace = (strArg) => {
-            const str = parseFloat(strArg)
-            return str === 0 ? 0 : `${2 * str}rpx`
-        }
-        return value.replace(pxRegExp, pxReplace)
+    // 正则匹配，(\d+)px 替换成为 (\d+)rpx
+    function pxReplace(value = '') {
+        const pxRegExp = /\b(\d*\.?\d+)px(\s|;|$)/gi;
+        const pxReplace = (matchStr, num, separate) => {
+            return 0 === num ? `0${separate}` : `${num}rpx${separate}`;
+        };
+
+        const result = value.replace(pxRegExp, pxReplace);
+        return result;
     }
 
     return through2.obj(function(file, encoding, cb) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -43,7 +43,7 @@ const px2Rpx = () => {
     function pxReplace(value = '') {
         const pxRegExp = /\b(\d*\.?\d+)px(\s|;|$)/gi;
         const pxReplace = (matchStr, num, separate) => {
-            return 0 === num ? `0${separate}` : `${num}rpx${separate}`;
+            return 0 === num ? `0${separate}` : `${2 * num}rpx${separate}`;
         };
 
         const result = value.replace(pxRegExp, pxReplace);


### PR DESCRIPTION
如果这个时候 px 所在为 base64 之类背景图之类的地方，就会存在问题。故修复。

例子：
输入： `"max-width:3px;max-height:12px;width: 3px;height: 6px;padding: 1px2;border: 1px 2px 3px 5px;background: url('data:image/png;base64,iVBOpx;');background: url('data:image/png;base64,iVBO12px;');margin: 12px 12px 15px 16px"`
输出： `"max-width:3rpx;max-height:12rpx;width: 3rpx;height: 6rpx;padding: 1px2;border: 1rpx 2rpx 3rpx 5rpx;background: url('data:image/png;base64,iVBOpx;');background: url('data:image/png;base64,iVBO12px;');margin: 12rpx 12rpx 15rpx 16rpx"`