### PR TITLE
'cell增加判断，减少无用渲染，影响页面渲染'

### DIFF
--- a/src/cell/index.js
+++ b/src/cell/index.js
@@ -181,6 +181,7 @@ baseComponent({
             }
         },
         updateIsLastElement(isLast) {
+            if(isLast === this.data.isLast) return;
             this.setData({ isLast })
         },
     },


### PR DESCRIPTION
cell条数多的时候500条左右，页面初次渲染会很卡5s左右才渲染出来。
500条数据，updateIsLastElement会执行500次，其中很多都是不必要的setData，只有最后一条数据才需要。故增加判断条件，提高性能。