### PR TITLE
hotfix the upload default timeout(member: zbm)

### DIFF
--- a/src/helpers/hooks/useNativeAPI.js
+++ b/src/helpers/hooks/useNativeAPI.js
@@ -85,7 +85,7 @@ export function uploadFile(options) {
         name = 'file',
         header = {},
         formData = {},
-        timeout = 20,
+        timeout = 20000,
         enableProfile = true,
         enableHttp2 = false,
         ...resetCbs


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在一个维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

[[English Template / 英文模板](?expand=1)]
-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

### 💡 需求背景和解决方案

1. 在使用upload组件时，发现请求无法到达服务端，经过调试js代码发现，微信小程序的uploadFile(API)的timeout参数单位为毫秒，代码中设置的默认值为：20，该值可理解为20秒，而非20毫秒，所以需要将20改为20000，以达到20秒的超时时间，否则请求无法提交，upload组件始终走onFail

### 📝 更新日志怎么写？

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |  合理设置upload组件上传默认时间  |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供